### PR TITLE
Change simulate request method from GET to POST

### DIFF
--- a/.vscode/arduino.json
+++ b/.vscode/arduino.json
@@ -1,0 +1,5 @@
+{
+    "board": "esp8266:esp8266:d1",
+    "configuration": "xtal=80,vt=flash,exception=disabled,ssl=all,eesz=4M,ip=lm2f,dbg=Disabled,lvl=None____,wipe=none,baud=921600",
+    "port": "COM8"
+}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "C:\\Users\\hanna\\AppData\\Local\\Arduino15\\packages\\esp8266\\tools\\**",
+                "C:\\Users\\hanna\\AppData\\Local\\Arduino15\\packages\\esp8266\\hardware\\esp8266\\2.5.2\\**"
+            ],
+            "forcedInclude": [],
+            "intelliSenseMode": "msvc-x64",
+            "compilerPath": "C:\\MinGW\\bin\\gcc.exe",
+            "cStandard": "c11",
+            "cppStandard": "c++17"
+        }
+    ],
+    "version": 4
+}

--- a/pages/simulatorweb.html
+++ b/pages/simulatorweb.html
@@ -25,6 +25,7 @@ custom_js_url:
   - https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.32.0/codemirror.min.js
   - https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/downloadjs/1.4.8/download.min.js
+  - https://unpkg.com/axios/dist/axios.min.js
 ---
 
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">


### PR DESCRIPTION
Previously, the simulate request was sent as a GET request, and the student code was sent as a query parameter. The request would fail when the student code was too long, because the URL was too long. Now, the simulate request is sent as a POST, so student code can be much longer.